### PR TITLE
Use https instead of git URLs for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "4bytes"]
 	path = 4bytes
-	url = git@github.com:ethereum-lists/4bytes.git
+	url = https://github.com/ethereum-lists/4bytes.git
 [submodule "trustwallet"]
 	path = trustwallet
-	url = git@github.com:trustwallet/assets.git
+	url = https://github.com/trustwallet/assets.git


### PR DESCRIPTION
This simplifies dockerized builds with git submodules as needed in this PR:
https://github.com/wmitsuda/erigon/pull/1