### PR TITLE
Add explicit checkout of tags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ We intend to release a compatible rebased version containing our changes every w
 
 ```
 git fetch --all
+git fetch otterscan --tags
 git checkout <version-tag-otterscan>
 ```
 


### PR DESCRIPTION
For some reason the instructions did NOT work for me, the only way I was able to get the tags to be able to check them out was to run `git fetch otterscan --tags` so I suggest that it be added here :shrug: