### PR TITLE
Replace protocol for cloning

### DIFF
--- a/docs/other-ways-to-run-otterscan.md
+++ b/docs/other-ways-to-run-otterscan.md
@@ -13,7 +13,7 @@ The entire build process will take place inside the docker multi-stage build.
 Clone Otterscan repo and its submodules. Checkout the tag corresponding to your Erigon + Otterscan patches. It uses the same version tag from Erigon + Otterscan repo, i.e., if you built the `v2021.07.01-otterscan`, you should build the `v2021.07.01-otterscan` of Otterscan.
 
 ```
-git clone --recurse-submodules git@github.com:wmitsuda/otterscan.git
+git clone --recurse-submodules https://github.com/wmitsuda/otterscan.git
 cd otterscan
 git checkout <version-tag-otterscan>
 DOCKER_BUILDKIT=1 docker build -t otterscan -f Dockerfile .


### PR DESCRIPTION
otherwise on a server where you do not have a key you can end up with:
```
$ git clone --recurse-submodules git@github.com:wmitsuda/otterscan.git
Cloning into 'otterscan'...
Warning: Permanently added the RSA host key for IP address '140.82.121.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

with https you do not need a key:

```
$ git clone --recurse-submodules https://github.com/wmitsuda/otterscan.git
Cloning into 'otterscan'...
remote: Enumerating objects: 1966, done.
remote: Counting objects: 100% (770/770), done.
remote: Compressing objects: 100% (408/408), done.
remote: Total 1966 (delta 431), reused 458 (delta 330), pack-reused 1196
Receiving objects: 100% (1966/1966), 893.74 KiB | 6.72 MiB/s, done.
Resolving deltas: 100% (1285/1285), done.
Submodule '4bytes' (https://github.com/ethereum-lists/4bytes.git) registered for path '4bytes'
Submodule 'trustwallet' (https://github.com/trustwallet/assets.git) registered for path 'trustwallet'
Cloning into '/home/gather/otterscan/4bytes'...
remote: Enumerating objects: 333320, done.        
remote: Counting objects: 100% (126744/126744), done.        
remote: Compressing objects: 100% (7043/7043), done.        
remote: Total 333320 (delta 93), reused 126704 (delta 63), pack-reused 206576
Receiving objects: 100% (333320/333320), 41.83 MiB | 8.25 MiB/s, done.
Resolving deltas: 100% (566/566), done.
Cloning into '/home/gather/otterscan/trustwallet'...
remote: Enumerating objects: 166463, done.        
remote: Counting objects: 100% (94/94), done.        
remote: Compressing objects: 100% (73/73), done.        
remote: Total 166463 (delta 43), reused 60 (delta 21), pack-reused 166369        
Receiving objects: 100% (166463/166463), 440.42 MiB | 7.55 MiB/s, done.
Resolving deltas: 100% (72008/72008), done.
Submodule path '4bytes': checked out '1cc7e25c840ae9d985c12768b0cbd0ece3fc5400'
Submodule path 'trustwallet': checked out '7bfa06acc125a4874d86bc1fa8e4547a46846e31'
```