### PR TITLE
Update Sourcify Remix plug. name, activate plugin

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -67,4 +67,4 @@ export const sourcifySourceFile = (
   )}/contracts/full_match/${chainId}/${address}/sources/${filepath}`;
 
 export const openInRemixURL = (checksummedAddress: string, networkId: number) =>
-  `https://remix.ethereum.org/#call=source-verification//fetchAndSave//${checksummedAddress}//${networkId}`;
+  `https://remix.ethereum.org/#activate=sourcify&call=sourcify//fetchAndSave//${checksummedAddress}//${networkId}`;


### PR DESCRIPTION
Was looking at the Otterscan code and noticed the Remix link: 

https://github.com/wmitsuda/otterscan/blob/fd9778443dc47155bee1d22358a10d8170f295f2/src/url.ts#L70

which uses the old plugin name `source-verification`. The plugin's name was changed to `sourcify`: https://github.com/ethereum/remix-plugins-directory/commit/4137abfe9d743d71cf3b339c9f0a2544901e11f7

So the old link should not be working.

Also added `activate` to the URL which activates the plugin for users who never used it or when there's a new clean Remix session. 