### PR TITLE
feat(nginx): enable rpc/ws proxying

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,32 +1,77 @@
-user  nginx;
-worker_processes  auto;
+user nginx;
+pid /var/run/nginx.pid;
+worker_processes auto;
+worker_rlimit_nofile 65535;
+error_log /var/log/nginx/error.log notice;
 
-error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
 
-#load_module modules/ngx_http_brotli_static_module.so;
+# load_module modules/ngx_http_brotli_static_module.so;
+
 
 events {
-    worker_connections  1024;
+    multi_accept on;
+    worker_connections 65535;
 }
 
-
 http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+    charset utf-8;
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    server_tokens off;
+    log_not_found off;
+    types_hash_max_size 4096;
+    types_hash_bucket_size 128;
+    client_max_body_size 16M;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    # MIME
+    include mime.types;
+    default_type application/octet-stream;
 
-    access_log  /var/log/nginx/access.log  main;
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
 
-    sendfile        on;
-    #tcp_nopush     on;
+    # Logging
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
 
-    keepalive_timeout  65;
 
-    #gzip  on;
+    sendfile on;
 
+    keepalive_timeout 65;
+
+    # Load configs
     include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+
+}
+
+server {
+
+    listen 80;
+    listen [::]:80;
+    server_name localhost;
+
+    location ^~ /ws {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_pass http://127.0.0.1:8546/;
+    }
+
+    location ^~ /rpc {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_pass http://127.0.0.1:8545/;
+    }
 }


### PR DESCRIPTION
IDK if you would want to merge this, this may be better left in the documents, if yo think so I can open a PR adding this config in the docs. 

This nginx.conf enables nginx to act as a service proxy / load balancer for the backing eth client. It also tunes the settings to generally handle more load.

I can be specific about the settings if you would like further clarification