### PR TITLE
DecodedLogSignature adaptation tuple

### DIFF
--- a/src/transaction/decoder/DecodedLogSignature.tsx
+++ b/src/transaction/decoder/DecodedLogSignature.tsx
@@ -12,7 +12,7 @@ const DecodedLogSignature: React.FC<DecodedLogSignatureProps> = ({ event }) => {
       {event.inputs.map((input, i) => (
         <span key={i}>
           {i > 0 ? ", " : ""}
-          <span>{input.format("full")}</span>
+          <span>{input.format ? input.format("full") : `${input.type} ${input.name}`}</span>
         </span>
       ))}
       ){event.anonymous ? " anonymous" : ""}


### PR DESCRIPTION
The page will error when the type is tuple, and displaying it in full will cause it to be very long. It is displayed directly as ```tuple[] param_name```