### PR TITLE
Add support for ERC-721 token transfer logs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,9 @@ export type TokenTransfer = {
   token: string;
   from: string;
   to: string;
-  value: BigNumber;
+  type: string;
+  value?: BigNumber;
+  tokenId?: BigNumber;
 };
 
 export type TokenMeta = {

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -256,13 +256,28 @@ export const useTokenTransfers = (
     }
 
     return txData.confirmedData.logs
-      .filter((l) => l.topics.length === 3 && l.topics[0] === TRANSFER_TOPIC)
-      .map((l) => ({
-        token: l.address,
-        from: getAddress(hexDataSlice(arrayify(l.topics[1]), 12)),
-        to: getAddress(hexDataSlice(arrayify(l.topics[2]), 12)),
-        value: BigNumber.from(l.data),
-      }));
+      .filter(
+        (l) =>
+          (l.topics.length === 3 || l.topics.length === 4) &&
+          l.topics[0] === TRANSFER_TOPIC
+      )
+      .map((l) =>
+        l.topics.length === 3
+          ? {
+              token: l.address,
+              from: getAddress(hexDataSlice(arrayify(l.topics[1]), 12)),
+              to: getAddress(hexDataSlice(arrayify(l.topics[2]), 12)),
+              value: BigNumber.from(l.data),
+              type: "erc20",
+            }
+          : {
+              token: l.address,
+              from: getAddress(hexDataSlice(arrayify(l.topics[1]), 12)),
+              to: getAddress(hexDataSlice(arrayify(l.topics[2]), 12)),
+              tokenId: BigNumber.from(l.topics[3]),
+              type: "erc721",
+            }
+      );
   }, [txData]);
 
   return transfers;


### PR DESCRIPTION
Fixes #723.

The code I wrote needs a lot of polish (hence the draft), but it does show ERC-721 transfers. The only distinction between ERC-20 and ERC-721 is the token ID is indexed also in ERC-721 transfers, so we just modify the topic length check to account for this.

ERC-20 and ERC-721 share the same topic because (uint256 amount) is the same type as (uint256 tokenId).